### PR TITLE
Show errors returned by the Asset Library API

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,10 @@ const axios = require('axios').default
       token: token,
     })
   } catch (error) {
-    core.setFailed(error.message)
+    if (error.isAxiosError) {
+      core.setFailed(`${error.message}: ${error.response.data.error}`)
+    } else {
+      core.setFailed(error.message)
+    }
   }
 })()


### PR DESCRIPTION
I attempted to use a tag name rather than commit hash as the
"download_commit" field. This fails with status code 403 and the
following JSON response body (reformatted for readability):

    {
      "error": "Using Git tags or branches is no longer supported.
                Please give a full Git commit hash instead, or use the
                Custom download provider for GitHub Releases downloads."
    }

However previously this action did not expose the details of the error
in the action log, so the only information in the action log was:

> Request failed with status code 403

Add the error message returned by the API to the failed status.
